### PR TITLE
Fix content collection configuration export

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -62,4 +62,4 @@ const docs = defineCollection({
     })
 })
 
-export const content = { blog, docs }
+export const collections = { blog, docs }


### PR DESCRIPTION
## Summary
- export the content collections from `src/content.config.ts` using the `collections` name Astro expects so collection schemas are applied

## Testing
- `bun run build` *(fails: missing assets @/assets/wechat-qrcode.jpg and @/assets/alipay-qrcode.jpg referenced by src/pages/projects/index.astro)*

------
https://chatgpt.com/codex/tasks/task_e_68c9839f7a9483238b7edaed0d23190a