### PR TITLE
Add Yokohama Snowly Blog repo subagent skill

### DIFF
--- a/.codex/skills/yokohama-snowly-blog/SKILL.md
+++ b/.codex/skills/yokohama-snowly-blog/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: yokohama-snowly-blog
+description: Maintain and extend the YokohamaSnowlyBlog Astro site. Use when working in this repo on blog or thoughts content, Astro pages/components/layouts, site configuration, content collections, or build/lint/check workflows, especially when a task should follow the existing content schema and project structure.
+---
+
+# Yokohama Snowly Blog
+
+Follow the existing Astro + astro-pure structure instead of inventing new patterns.
+
+## Quick workflow
+
+1. Read `references/repo-map.md` before making non-trivial changes.
+2. Identify the content type or UI layer you need to edit.
+3. Keep changes small and consistent with the current site conventions.
+4. Run the narrowest useful validation command first, then broader checks when the change touches shared config or rendering.
+
+## Work by area
+
+### Content updates
+
+- Add long-form posts under `src/content/blog/`.
+- Add short updates under `src/content/thoughts/`.
+- Add documentation-style pages under `src/content/docs/`.
+- Match the collection schema in `src/content.config.ts`.
+- Keep titles and descriptions within the schema limits.
+- Prefer lowercase tags because the schema normalizes and deduplicates them.
+- If a post needs images, keep them beside that post when the current folder already uses colocated assets.
+
+### Site configuration
+
+- Edit `src/site.config.ts` for navigation, footer, integrations, and theme-level settings.
+- Edit `src/config/site.ts` for origin and base-path behavior.
+- Preserve `withStaticBase(...)` / base-path-aware links when changing internal asset or page URLs.
+
+### UI and page changes
+
+- Reuse existing components and layouts in `src/components/` and `src/layouts/` before adding new abstractions.
+- Keep route-specific page logic in `src/pages/`.
+- Prefer small, local edits over broad restructuring unless the task explicitly requires a refactor.
+
+## Validation
+
+Run the smallest relevant command first:
+
+- `bun check` for Astro/type/content validation.
+- `bun build` for full production verification.
+- `bun lint` when editing Astro/TS/JS source files.
+- `bun format` after content or source edits if formatting drift is likely.
+
+If Bun is unavailable, fall back to the equivalent npm script only if the environment already supports it.
+
+## References
+
+- Read `references/repo-map.md` for the repo layout, common commands, and edit guidance.

--- a/.codex/skills/yokohama-snowly-blog/agents/openai.yaml
+++ b/.codex/skills/yokohama-snowly-blog/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Yokohama Snowly Blog"
+  short_description: "Repo subagent for Astro blog maintenance."
+  default_prompt: "Use $yokohama-snowly-blog to make focused changes in the YokohamaSnowlyBlog Astro repo that follow its content schemas, routing structure, and Bun-based validation workflow."

--- a/.codex/skills/yokohama-snowly-blog/references/repo-map.md
+++ b/.codex/skills/yokohama-snowly-blog/references/repo-map.md
@@ -1,0 +1,81 @@
+# Repo map
+
+## Stack
+
+- Astro site powered by `astro-pure`.
+- Package manager and scripts are centered on Bun via `package.json` and `bun.lock`.
+- Content is driven by Astro collections in `src/content.config.ts`.
+
+## Key files and folders
+
+### Root
+
+- `package.json`: primary dev/build/check/lint/format commands.
+- `astro.config.ts`: Astro integration setup.
+- `public/`: static assets served as-is.
+- `src/`: application code, pages, layouts, content, and assets.
+
+### Content
+
+- `src/content/blog/`: blog posts, often as either `index.mdx` inside a post folder or a single `.mdx` file.
+- `src/content/thoughts/`: short-form notes with lightweight frontmatter.
+- `src/content/docs/`: documentation pages used by the theme.
+- `src/content.config.ts`: schema rules for `blog`, `docs`, and `thoughts` collections.
+
+### App structure
+
+- `src/pages/`: route entrypoints.
+- `src/components/`: reusable page sections and widgets.
+- `src/layouts/`: shared page/post layouts.
+- `src/site.config.ts`: theme, navigation, footer, integrations, and terms cards.
+- `src/config/site.ts`: canonical origin and base path.
+- `src/utils/base-path.ts` and `src/utils/url.ts`: URL helpers worth reusing before creating new ones.
+
+## Content schema notes
+
+### Blog
+
+Required frontmatter includes:
+
+- `title`
+- `description`
+- `publishDate`
+
+Optional but common fields include:
+
+- `updatedDate`
+- `heroImage`
+- `tags`
+- `language`
+- `draft`
+- `comment`
+
+### Thoughts
+
+Required frontmatter includes:
+
+- `publishDate`
+
+Optional fields include:
+
+- `title`
+- `updatedDate`
+- `tags`
+- `language`
+- `draft`
+
+## Editing guidance
+
+- Preserve the existing content organization before introducing new directories.
+- Prefer colocated post assets for posts that already use a folder with `index.mdx`.
+- Use base-path-aware helpers for internal links and assets when editing config.
+- Keep tag values simple and lowercase-friendly.
+- Avoid changing generated or binary assets unless the task explicitly calls for it.
+
+## Useful commands
+
+- `bun check`
+- `bun build`
+- `bun lint`
+- `bun format`
+- `bun clean`


### PR DESCRIPTION
### Motivation

- Provide a repo-local Codex skill/subagent to make focused, repo-aware changes to this Astro blog following existing conventions and content schemas.
- Capture where to edit content, site configuration, and UI layers so automated agents and contributors follow consistent patterns.
- Supply quick guidance for validation commands and a small repo map to reduce friction when making changes.

### Description

- Add a new skill under `.codex/skills/yokohama-snowly-blog` with trigger metadata in `SKILL.md` describing when and how to use the subagent and recommended workflows.
- Add `agents/openai.yaml` to expose `display_name`, `short_description`, and a `default_prompt` so the skill can be discovered and invoked by the agent UI.
- Add `references/repo-map.md` documenting the repo layout, content collection expectations, editing guidance, and useful Bun/Astro commands for maintainers and automated workflows.

### Testing

- Ran the skill generator `python /opt/codex/skills/.system/skill-creator/scripts/generate_openai_yaml.py` which failed with `ModuleNotFoundError: No module named 'yaml'`, so automated YAML generation could not complete.
- Ran the skill validator `python /opt/codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/yokohama-snowly-blog` which failed due to the missing Python `yaml` package, so validation did not complete.
- Ran repository validation via `bun check` which failed because the project environment is missing the `@unocss/astro` package, preventing Astro from loading the config and completing the check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf007b9be48323a87492336ba59194)