### PR TITLE
Set up cloud dev environment (Bun + Astro) and add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a static blog built with Astro + `astro-pure`, managed with the **Bun** package manager (`bun.lock`). Standard scripts live in `package.json` (`dev`, `check`, `build`, `lint`, `format`).
+
+- Bun is preinstalled in the cloud environment and on `PATH`; the update script runs `bun install`. Use Bun (not npm/pnpm) so the lockfile stays consistent.
+- Run the dev server with `bun dev` (Astro dev server on port `4321`).
+- **The site uses a base path.** The dev server serves everything under `http://localhost:4321/YokohamaSnowlyBlog` — the bare root `http://localhost:4321/` returns 404. Always include the `/YokohamaSnowlyBlog` prefix when loading pages or writing links (see `src/config/site.ts` / `withStaticBase(...)` helpers).
+- `bun check` (astro check) and `bun build` both pass cleanly. `bun build` also runs `astro-pure check` and Pagefind indexing.
+- `bun lint` currently reports pre-existing errors in `src/` (unused vars, `no-explicit-any`, etc.); these are existing repo issues, not an environment problem.
+- Content lives in `src/content/{blog,thoughts,docs}` and follows the schema in `src/content.config.ts`. The dev server hot-reloads content edits.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Astro + `astro-pure` blog (managed with Bun) and documents non-obvious startup caveats for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering: Bun as the package manager, `bun dev`/`check`/`build`/`lint` commands, and the key gotcha that the dev server serves under the base path `/YokohamaSnowlyBlog` (bare `/` returns 404).
- Update script configured to `bun install` (dependency refresh only).

No application code was modified.

## Verification

- `bun install` — installs 739 packages successfully.
- `bun check` — 0 errors, 0 warnings (3 hints, pre-existing).
- `bun run build` — 35 pages built + Pagefind index generated.
- `bun dev` — dev server runs at `http://localhost:4321/YokohamaSnowlyBlog`; browsed home page, blog listing, a full blog post, and the thoughts page with tag filtering.

`bun lint` reports pre-existing lint errors in `src/` (unused vars, `no-explicit-any`); these are existing repo issues, not environment problems.

### Walkthrough

[astro_blog_dev_walkthrough.mp4](https://cursor.com/agents/bc-46c137b9-c7e3-4285-89da-d69ee4479145/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_blog_dev_walkthrough.mp4)

Browsing the running dev site end-to-end.

[Home page](https://cursor.com/agents/bc-46c137b9-c7e3-4285-89da-d69ee4479145/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_page.webp)
[Thoughts filtered by tag](https://cursor.com/agents/bc-46c137b9-c7e3-4285-89da-d69ee4479145/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fthoughts_filtered.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46c137b9-c7e3-4285-89da-d69ee4479145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46c137b9-c7e3-4285-89da-d69ee4479145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

