### PR TITLE
Tech-minimal visual redesign

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "astro-theme-pure",

--- a/public/styles/global.css
+++ b/public/styles/global.css
@@ -1,7 +1,7 @@
 /* Animation */
 @keyframes fade-in-up {
   0% {
-    transform: translateY(2rem);
+    transform: translateY(1rem);
     opacity: 0;
   }
   100% {
@@ -11,24 +11,23 @@
 }
 .animate {
   opacity: 0;
-  animation: 300ms fade-in-up;
+  animation: 500ms fade-in-up cubic-bezier(0.22, 1, 0.36, 1);
   animation-fill-mode: forwards;
 }
 @media (prefers-reduced-motion) {
   .animate {
-    opacity: 0;
-    animation: 100ms fade-in-up;
-    animation-fill-mode: forwards;
+    opacity: 1;
+    animation: none;
   }
 }
 #content-header {
-  animation-delay: 50ms;
+  animation-delay: 40ms;
 }
 #content {
-  animation-delay: 100ms;
+  animation-delay: 120ms;
 }
 #sidebar {
-  animation-delay: 150ms;
+  animation-delay: 180ms;
 }
 
 /* Katex */

--- a/src/assets/styles/app.css
+++ b/src/assets/styles/app.css
@@ -11,59 +11,107 @@
   font-style: italic;
   font-display: swap;
 }
-html {
-  font-family: 'Satoshi', sans-serif;
-}
 
-/* Theme */
 :root {
-  --background: 210 33% 99%;
-  --foreground: 240 10% 3.9%;
+  --font-sans: 'Satoshi', sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  /* Cool tech-minimal light */
+  --background: 210 24% 97%;
+  --foreground: 216 28% 10%;
   --card: 0 0% 100%;
-  --card-foreground: 240 10% 3.9%;
+  --card-foreground: 216 28% 10%;
   --popover: 0 0% 100%;
-  --popover-foreground: 240 10% 3.9%;
-  --primary: 200 29% 45%;
-  --primary-foreground: 0 0% 92.5%;
-  --secondary: 240 4.8% 95.9%;
-  --secondary-foreground: 240 5.9% 10%;
-  --muted: 240 4.8% 95%;
-  --muted-foreground: 240 3.8% 28.1%;
-  --accent: 240 4.8% 95.9%;
-  --accent-foreground: 240 5.9% 10%;
+  --popover-foreground: 216 28% 10%;
+  --primary: 191 72% 32%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 210 16% 94%;
+  --secondary-foreground: 216 20% 16%;
+  --muted: 210 16% 94%;
+  --muted-foreground: 215 12% 38%;
+  --accent: 191 28% 93%;
+  --accent-foreground: 191 55% 22%;
   --destructive: 0 72.22% 50.59%;
   --destructive-foreground: 0 0% 98%;
-  --border: 240 5.9% 88%;
-  --input: 240 5.9% 90%;
-  --ring: 240 5.9% 10%;
-  --radius: 0.5rem;
+  --border: 214 16% 84%;
+  --input: 214 16% 88%;
+  --ring: 191 72% 32%;
+  --radius: 0.25rem;
+
+  --surface-glow: 191 60% 45%;
+  --grid-line: 214 18% 78%;
 }
+
 .dark {
-  --background: 240 20.54% 5.2%;
-  --foreground: 0 0% 98%;
-  --card: 240 10% 3.9%;
-  --card-foreground: 0 0% 98%;
-  --popover: 240 10% 3.9%;
-  --popover-foreground: 0 0% 98%;
-  --primary: 195 95% 85%;
-  --primary-foreground: 240 3.7% 15.9%;
-  --secondary: 240 3.7% 15.9%;
-  --secondary-foreground: 0 0% 98%;
-  --muted: 240 5.9% 12%;
-  --muted-foreground: 240 5% 74.9%;
-  --accent: 240 3.7% 15.9%;
-  --accent-foreground: 0 0% 98%;
+  --background: 220 22% 6%;
+  --foreground: 210 20% 96%;
+  --card: 220 18% 8%;
+  --card-foreground: 210 20% 96%;
+  --popover: 220 18% 8%;
+  --popover-foreground: 210 20% 96%;
+  --primary: 187 58% 58%;
+  --primary-foreground: 220 22% 8%;
+  --secondary: 220 14% 14%;
+  --secondary-foreground: 210 20% 96%;
+  --muted: 220 14% 12%;
+  --muted-foreground: 215 12% 68%;
+  --accent: 220 14% 14%;
+  --accent-foreground: 187 58% 70%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 0 0% 98%;
-  --border: 240 3.7% 19.9%;
-  --input: 240 3.7% 15.9%;
-  --ring: 240 4.9% 83.9%;
+  --border: 220 12% 18%;
+  --input: 220 12% 16%;
+  --ring: 187 58% 58%;
+
+  --surface-glow: 187 50% 40%;
+  --grid-line: 220 12% 22%;
 }
+
 :root {
   --un-default-border-color: hsl(var(--border) / 1);
 }
+
+html {
+  font-family: var(--font-sans);
+}
+
 html.dark {
   color-scheme: dark;
+}
+
+body {
+  background-color: hsl(var(--background));
+  background-image:
+    radial-gradient(
+      1200px 600px at 12% -10%,
+      hsl(var(--surface-glow) / 0.1),
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 500px at 90% 8%,
+      hsl(210 40% 70% / 0.08),
+      transparent 55%
+    ),
+    linear-gradient(hsl(var(--grid-line) / 0.28) 1px, transparent 1px),
+    linear-gradient(90deg, hsl(var(--grid-line) / 0.28) 1px, transparent 1px);
+  background-size:
+    auto,
+    auto,
+    48px 48px,
+    48px 48px;
+  background-attachment: fixed;
+}
+
+.dark body {
+  background-image:
+    radial-gradient(
+      1000px 520px at 10% -8%,
+      hsl(var(--surface-glow) / 0.14),
+      transparent 58%
+    ),
+    radial-gradient(800px 420px at 92% 0%, hsl(210 40% 40% / 0.1), transparent 50%),
+    linear-gradient(hsl(var(--grid-line) / 0.45) 1px, transparent 1px),
+    linear-gradient(90deg, hsl(var(--grid-line) / 0.45) 1px, transparent 1px);
 }
 
 /* Global */
@@ -71,5 +119,99 @@ a {
   transition: color 0.2s ease;
   &:hover {
     color: hsl(var(--primary) / var(--un-text-opacity, 1));
+  }
+}
+
+.font-mono,
+.tech-label {
+  font-family: var(--font-mono);
+}
+
+.tech-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+}
+
+/* Full-bleed utility for hero planes */
+.bleed {
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+}
+
+/* Homepage motions */
+@keyframes hero-rise {
+  from {
+    opacity: 0;
+    transform: translateY(1.25rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes grid-drift {
+  from {
+    background-position:
+      0 0,
+      0 0,
+      0 0,
+      0 0;
+  }
+  to {
+    background-position:
+      0 0,
+      0 0,
+      48px 24px,
+      24px 48px;
+  }
+}
+
+@keyframes line-grow {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+.hero-copy > * {
+  opacity: 0;
+  animation: hero-rise 700ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.hero-copy > *:nth-child(1) {
+  animation-delay: 80ms;
+}
+.hero-copy > *:nth-child(2) {
+  animation-delay: 180ms;
+}
+.hero-copy > *:nth-child(3) {
+  animation-delay: 280ms;
+}
+.hero-copy > *:nth-child(4) {
+  animation-delay: 380ms;
+}
+
+.hero-media {
+  animation: hero-rise 900ms cubic-bezier(0.22, 1, 0.36, 1) 120ms both;
+}
+
+.hero-rule {
+  transform-origin: left;
+  animation: line-grow 800ms cubic-bezier(0.22, 1, 0.36, 1) 420ms both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-copy > *,
+  .hero-media,
+  .hero-rule {
+    animation: none;
+    opacity: 1;
+    transform: none;
   }
 }

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -54,6 +54,12 @@ const socialImageURL = new URL(ogImage ?? defaultOgImage, Astro.url).href
   type='font/ttf'
   crossorigin
 />
+<link rel='preconnect' href='https://fonts.googleapis.com' />
+<link rel='preconnect' href='https://fonts.gstatic.com' crossorigin />
+<link
+  href='https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap'
+  rel='stylesheet'
+/>
 
 {/* Canonical URL */}
 <link rel='canonical' href={canonicalURL} />

--- a/src/components/custom/Footer.astro
+++ b/src/components/custom/Footer.astro
@@ -17,10 +17,10 @@ const footerLink1 = footerConf.links?.filter(({ pos }) => pos === 1) || []
 ---
 
 <footer class='mx-auto mb-5 mt-16 w-full'>
-  <div class='border-t pt-5'>
+  <div class='border-t border-border pt-5'>
     <div class='flex items-center gap-y-3 max-sm:flex-col sm:justify-between sm:gap-y-0'>
       <div
-        class='flex items-center gap-x-4 gap-y-2 text-muted-foreground max-sm:flex-col [&_a]:text-foreground'
+        class='flex items-center gap-x-4 gap-y-2 font-mono text-xs tracking-wide text-muted-foreground max-sm:flex-col [&_a]:text-foreground'
       >
         {/* Position 1 */}
         {

--- a/src/components/custom/Header.astro
+++ b/src/components/custom/Header.astro
@@ -11,10 +11,10 @@ const menuItems = config.header.menu?.map((item) => ({
 ---
 
 <header-component
-  class='group sticky top-4 z-50 max-md:z-30 mb-12 flex items-center justify-between rounded-xl border border-transparent max-sm:py-1 sm:rounded-2xl'
+  class='group sticky top-4 z-50 max-md:z-30 mb-10 flex items-center justify-between rounded-md border border-transparent max-sm:py-1'
 >
   <a
-    class='z-30 text-xl font-semibold group-[.not-top]:ms-2 sm:group-[.not-top]:ms-3'
+    class='z-30 font-mono text-sm font-medium tracking-[0.08em] uppercase group-[.not-top]:ms-2 sm:group-[.not-top]:ms-3'
     style='transition:margin-inline 0.3s'
     href={withBase('/')}
     aria-label='Brand'>{config.title}</a
@@ -31,7 +31,7 @@ const menuItems = config.header.menu?.map((item) => ({
           menuItems.map((item) => (
             <a
               href={item.href}
-              class='w-full flex-none grow py-2 text-right font-medium transition-none hover:text-primary sm:w-fit sm:px-3'
+              class='w-full flex-none grow py-2 text-right text-sm font-medium tracking-wide transition-none hover:text-primary sm:w-fit sm:px-3'
               aria-label='Nav menu item'
             >
               {item.title}
@@ -51,7 +51,7 @@ const menuItems = config.header.menu?.map((item) => ({
     <div class='z-30 flex gap-x-4 group-[.not-top]:gap-x-2' style='transition:gap 0.3s'>
       <button
         id='toggleDarkMode'
-        class='group/dark box-content size-5 rounded-md border p-1.5 transition-colors hover:bg-border sm:group-[.not-top]:rounded-xl'
+        class='group/dark box-content size-5 rounded-md border p-1.5 transition-colors hover:bg-border'
       >
         <span class='sr-only'>Dark Theme</span>
         <Icon class='system size-5 group-hover/dark:text-primary' name='computer' />
@@ -60,7 +60,7 @@ const menuItems = config.header.menu?.map((item) => ({
       </button>
       <button
         id='toggleMenu'
-        class='rounded-md border p-1.5 transition-colors hover:bg-border sm:hidden sm:group-[.not-top]:rounded-xl'
+        class='rounded-md border p-1.5 transition-colors hover:bg-border sm:hidden'
       >
         <span class='sr-only'>Menu</span>
         <Icon class='size-5' name='menu' />
@@ -129,15 +129,12 @@ const menuItems = config.header.menu?.map((item) => ({
     &.not-top {
       --un-border-opacity: 1;
       border-color: hsl(var(--border) / var(--un-border-opacity));
-      --un-bg-opacity: 1;
+      --un-bg-opacity: 0.88;
       background-color: hsl(var(--background) / var(--un-bg-opacity));
+      backdrop-filter: blur(10px);
       padding-left: 0.375rem;
       padding-right: 0.375rem;
-      box-shadow:
-        rgb(255, 255, 255) 0px 0px 0px 0px,
-        rgba(24, 24, 27, 0.08) 0px 0px 0px 1px,
-        rgba(39, 39, 42, 0.08) 0px 10px 15px -3px,
-        rgba(39, 39, 42, 0.08) 0px 4px 6px -4px;
+      box-shadow: 0 1px 0 hsl(var(--border) / 0.8);
     }
     &[data-show='false']:not(.expanded) {
       transform: translateY(-5rem);
@@ -166,11 +163,7 @@ const menuItems = config.header.menu?.map((item) => ({
       grid-template-rows: 1fr;
     }
     .expanded.not-top #headerExpandContent {
-      box-shadow:
-        rgb(255, 255, 255) 0px 0px 0px 0px,
-        rgba(24, 24, 27, 0.08) 0px 0px 0px 1px,
-        rgba(39, 39, 42, 0.08) 0px 10px 15px -3px,
-        rgba(39, 39, 42, 0.08) 0px 4px 6px -4px;
+      box-shadow: 0 1px 0 hsl(var(--border) / 0.8);
     }
 
     /* header component after */

--- a/src/components/home/Quote.astro
+++ b/src/components/home/Quote.astro
@@ -5,14 +5,13 @@ const { class: className } = Astro.props
 ---
 
 <quote-component class={cn('not-prose inline-block', className)}>
-  <div class='flex flex-row items-center gap-x-3 rounded-full border px-4 py-2 text-sm shadow-sm'>
+  <div class='quote-shell flex items-center gap-x-3 px-1 py-2 text-sm'>
     <span class='relative flex items-center justify-center'>
-      <span
-        class='absolute size-2 animate-ping rounded-full border border-green-400 bg-green-400 opacity-75'
-      ></span>
-      <span class='size-2 rounded-full bg-green-400'></span>
+      <span class='size-1.5 rounded-[1px] bg-primary'></span>
     </span>
-    <p id='quote-sentence' class='font-medium text-muted-foreground'>想做自由的灵魂，有用的栋梁</p>
+    <p id='quote-sentence' class='font-mono text-muted-foreground'>
+      想做自由的灵魂，有用的栋梁
+    </p>
   </div>
 </quote-component>
 
@@ -42,3 +41,10 @@ const { class: className } = Astro.props
   }
   customElements.define('quote-component', Quote)
 </script>
+
+<style>
+  .quote-shell {
+    border-top: 1px solid hsl(var(--border));
+    border-bottom: 1px solid hsl(var(--border));
+  }
+</style>

--- a/src/components/home/Section.astro
+++ b/src/components/home/Section.astro
@@ -1,12 +1,23 @@
 ---
 import { cn } from 'astro-pure/utils'
 
-const { class: className, title } = Astro.props
+type Props = {
+  class?: string
+  title: string
+  index?: string
+}
+
+const { class: className, title, index } = Astro.props
 ---
 
-<section class={cn('flex flex-col gap-y-5 md:flex-row md:gap-y-0', className)}>
-  <div class='text-xl font-semibold md:min-w-36'>
-    <h2>{title}</h2>
+<section class={cn('flex flex-col gap-y-5 md:flex-row md:gap-x-8 md:gap-y-0', className)}>
+  <div class='md:min-w-36 md:max-w-36'>
+    {
+      index && (
+        <p class='tech-label mb-2'>{index}</p>
+      )
+    }
+    <h2 class='text-xl font-semibold tracking-tight'>{title}</h2>
   </div>
   <div class='flex flex-1 flex-col gap-y-3'>
     <slot />

--- a/src/components/home/SkillLayout.astro
+++ b/src/components/home/SkillLayout.astro
@@ -1,6 +1,4 @@
 ---
-import { Button } from 'astro-pure/user'
-
 type Props = {
   title: string
   skills: string[]
@@ -10,8 +8,22 @@ const { title, skills } = Astro.props
 ---
 
 <div class='flex flex-col gap-y-2 md:flex-row md:gap-x-5 md:gap-y-0'>
-  <h3 class='w-1/5 font-medium'>{title}</h3>
-  <div class='flex flex-row flex-wrap gap-x-4 gap-y-2 md:w-4/5'>
-    {skills.map((skill: string) => <Button as='button' title={skill} variant='pill' />)}
-  </div>
+  <h3 class='tech-label w-full pt-1 md:w-1/5'>{title}</h3>
+  <ul class='flex flex-row flex-wrap gap-2 md:w-4/5'>
+    {
+      skills.map((skill: string) => (
+        <li class='skill-chip font-mono text-sm text-foreground/90'>{skill}</li>
+      ))
+    }
+  </ul>
 </div>
+
+<style>
+  .skill-chip {
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--card) / 0.7);
+    padding: 0.3rem 0.65rem;
+    border-radius: 0.2rem;
+    letter-spacing: 0.01em;
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -26,34 +26,34 @@ const {
   <head>
     <BaseHead {articleDate} {description} {ogImage} {title} />
     <script is:inline>
-      // Default to dark theme on first visit
+      // Default to light tech-minimal theme on first visit
       try {
         const storage = window.localStorage
         if (!storage.getItem('theme')) {
-          storage.setItem('theme', 'dark')
-          document.documentElement.classList.add('dark')
+          storage.setItem('theme', 'light')
+          document.documentElement.classList.remove('dark')
           document
             .querySelector('meta[name="theme-color"]')
-            ?.setAttribute('content', '#0B0B10')
+            ?.setAttribute('content', '#F4F7FA')
         }
       } catch {}
     </script>
     <ThemeProvider />
   </head>
 
-  <body class='flex justify-center bg-background text-foreground' {...props}>
+  <body class='flex justify-center text-foreground' {...props}>
     {
       highlightColor && (
         <div
           id='highlight-gradient'
-          class='pointer-events-none absolute start-0 top-0 z-0 h-screen w-full opacity-25'
-          style={`background-image:linear-gradient(${highlightColor},transparent)`}
+          class='pointer-events-none absolute start-0 top-0 z-0 h-[70vh] w-full opacity-20'
+          style={`background-image:linear-gradient(180deg,${highlightColor},transparent)`}
         />
       )
     }
-    <div class='w-full max-w-[70rem] px-4 sm:px-7 lg:px-10 min-h-[100dvh] flex flex-col justify-between'>
+    <div class='relative z-10 flex min-h-[100dvh] w-full max-w-[70rem] flex-col justify-between px-4 sm:px-7 lg:px-10'>
       <Header />
-      <div class='flex-1 w-full'>
+      <div class='w-full flex-1'>
         <slot />
       </div>
       <Footer />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -76,20 +76,28 @@ const education = [
         allPostsByDate.length > 0 && (
           <Section title='Posts' index='02'>
             <ul class='post-list flex flex-col'>
-              {allPostsByDate.map((p) => (
-                <li>
-                  <a class='post-row group' href={withBase(`blog/${p.id}`)} data-astro-prefetch>
-                    <FormattedDate
-                      class='post-date font-mono text-xs text-muted-foreground'
-                      date={p.data.updatedDate ?? p.data.publishDate}
-                    />
-                    <span class='post-title group-hover:text-primary'>{p.data.title}</span>
-                    <span class='post-arrow text-muted-foreground group-hover:text-primary' aria-hidden='true'>
-                      →
-                    </span>
-                  </a>
-                </li>
-              ))}
+              {allPostsByDate.map((p) => {
+                const postDate = p.data.updatedDate ?? p.data.publishDate
+                return (
+                  <li>
+                    <a class='post-row group' href={withBase(`blog/${p.id}`)} data-astro-prefetch>
+                      {postDate && (
+                        <FormattedDate
+                          class='post-date font-mono text-xs text-muted-foreground'
+                          date={postDate}
+                        />
+                      )}
+                      <span class='post-title group-hover:text-primary'>{p.data.title}</span>
+                      <span
+                        class='post-arrow text-muted-foreground group-hover:text-primary'
+                        aria-hidden='true'
+                      >
+                        →
+                      </span>
+                    </a>
+                  </li>
+                )
+              })}
             </ul>
             <a class='link-ahead mt-3 self-end' href={withBase('blog')}>More posts</a>
           </Section>
@@ -155,7 +163,7 @@ const education = [
     padding: 0.55rem 1.1rem;
     border-radius: 0.25rem;
     font-size: 0.92rem;
-    font-weight: 550;
+    font-weight: 500;
     letter-spacing: 0.01em;
     transition:
       background-color 0.2s ease,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import { Image } from 'astro:assets'
 import Quote from '@/components/home/Quote.astro'
 import { getBlogCollection, sortMDByDate } from 'astro-pure/server'
 import { FormattedDate } from 'astro-pure/user'
-import heroVisual from '@/assets/projects/wen-qiao-g_w8I64FiO0-unsplash.jpg'
+import heroVisual from '@/assets/projects/angelica-teran-Bk9hpaXHK4o-unsplash.jpg'
 import PageLayout from '@/layouts/BaseLayout.astro'
 import Section from '@/components/home/Section.astro'
 import SkillLayout from '@/components/home/SkillLayout.astro'
@@ -37,8 +37,8 @@ const education = [
       <div class='hero-media absolute inset-0'>
         <Image
           src={heroVisual}
-          alt='Minimalistic architectural interior'
-          class='h-full w-full object-cover'
+          alt='Modern architectural facade'
+          class='hero-image h-full w-full object-cover'
           loading='eager'
           widths={[720, 1080, 1600, 2200]}
           sizes='100vw'
@@ -48,16 +48,16 @@ const education = [
 
       <div class='relative z-10 mx-auto flex min-h-[88vh] w-full max-w-[70rem] flex-col justify-end px-4 pb-14 pt-28 sm:px-7 sm:pb-16 lg:px-10'>
         <div class='hero-copy max-w-2xl'>
-          <p class='tech-label mb-4 text-white/75'>Personal archive</p>
+          <p class='tech-label mb-4 text-white/80'>Personal archive</p>
           <h1 class='brand-title text-white'>Yokohama Snowly</h1>
-          <p class='mt-5 max-w-xl text-base leading-relaxed text-white/80 sm:text-lg'>
+          <p class='mt-5 max-w-xl text-base leading-relaxed text-white/85 sm:text-lg'>
             CS / Applied Math / Neuroscience — building clear systems with quiet precision.
           </p>
           <div class='mt-8 flex flex-wrap items-center gap-3'>
             <a class='cta-primary' href={withBase('blog')}>Read the blog</a>
             <a class='cta-ghost' href={withBase('about')}>About me</a>
           </div>
-          <div class='hero-rule mt-10 h-px w-28 bg-white/50'></div>
+          <div class='hero-rule mt-10 h-px w-28 bg-white/55'></div>
         </div>
       </div>
     </section>
@@ -140,17 +140,32 @@ const education = [
 </PageLayout>
 
 <style>
+  .hero {
+    background: hsl(216 28% 10%);
+  }
+
   .brand-title {
     font-size: clamp(2.6rem, 8vw, 4.75rem);
     font-weight: 700;
     letter-spacing: -0.04em;
     line-height: 0.95;
+    text-shadow: 0 1px 18px hsl(216 28% 8% / 0.35);
+  }
+
+  .hero-image {
+    object-position: center 40%;
+    filter: saturate(0.78) contrast(1.05);
   }
 
   .hero-veil {
     background:
-      linear-gradient(180deg, hsl(216 28% 8% / 0.18) 0%, hsl(216 28% 8% / 0.55) 48%, hsl(216 28% 8% / 0.82) 100%),
-      linear-gradient(90deg, hsl(216 28% 8% / 0.35) 0%, transparent 55%);
+      linear-gradient(
+        180deg,
+        hsl(216 28% 8% / 0.42) 0%,
+        hsl(216 28% 8% / 0.62) 42%,
+        hsl(216 28% 8% / 0.88) 100%
+      ),
+      linear-gradient(90deg, hsl(216 28% 8% / 0.55) 0%, hsl(216 28% 8% / 0.2) 58%, transparent 100%);
   }
 
   .cta-primary,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,152 +2,243 @@
 import { Image } from 'astro:assets'
 
 import Quote from '@/components/home/Quote.astro'
-import PostPreview from '@/components/custom/PostPreview.astro'
 import { getBlogCollection, sortMDByDate } from 'astro-pure/server'
-import { Button, Card, Icon, Label } from 'astro-pure/user'
-import eduFutureGadgetLab from '@/assets/projects/education-future-gadget-lab.png'
-import eduRdfz from '@/assets/projects/education-rdfz.png'
+import { FormattedDate } from 'astro-pure/user'
+import heroVisual from '@/assets/projects/wen-qiao-g_w8I64FiO0-unsplash.jpg'
 import PageLayout from '@/layouts/BaseLayout.astro'
-import ProjectCard from '@/components/home/ProjectCard.astro'
 import Section from '@/components/home/Section.astro'
 import SkillLayout from '@/components/home/SkillLayout.astro'
-import avatar from '@/assets/avatar.png'
-import config from '@/site-config'
 import { withBase } from '@/utils/url'
 
 const languages = ['Html', 'JavaScript', 'CSS', 'Shell', 'C', 'Python', 'Java']
 const frontend = ['TypeScript', 'Vite', 'Webpack', 'Astro']
 const backend = ['Vercel', 'Waline']
 
-const MAX_POSTS = 10
+const MAX_POSTS = 6
 const allPosts = await getBlogCollection()
-const publishedPosts = allPosts.filter(post => !post.data.draft)
+const publishedPosts = allPosts.filter((post) => !post.data.draft)
 const allPostsByDate = sortMDByDate(publishedPosts).slice(0, MAX_POSTS)
+
+const education = [
+  {
+    heading: '未来ガジェット研究所',
+    subheading: 'Brain Computer Interaction for future haven'
+  },
+  {
+    heading: '中国人民大学附属中学',
+    subheading: 'C1'
+  }
+]
 ---
 
-<PageLayout meta={{ title: 'Home' }} highlightColor='#659EB9'>
-  <main class='flex w-full flex-col items-center'>
-    <section class='animate mb-10 flex flex-col items-center gap-y-7' id='content-header'>
-      <Image
-        src={avatar}
-        alt='profile'
-        class='h-28 w-auto rounded-full border p-1'
-        loading='eager'
-      />
-
-      <div class='flex flex-col items-center gap-y-4'>
-  <h1 class='text-3xl font-bold'>Yokohama Snowly</h1>
-        <div class='flex flex-wrap justify-center gap-x-7 gap-y-3'>
-          <Label title='Houston, USA'>
-            <Icon name='location' class='size-5' slot='icon' />
-          </Label>
-          <Label
-            title='Source code'
-            as='a'
-            href='https://github.com/user309dec/YokohamaSnowlyBlog'
-            target='_blank'
-          >
-            <Icon name='github' class='size-5' slot='icon' />
-          </Label>
-        </div>
+<PageLayout meta={{ title: 'Home' }} highlightColor='#2A9BB0'>
+  <main class='flex w-full flex-col'>
+    <section class='bleed hero relative -mt-6 mb-16 overflow-hidden sm:-mt-8' id='content-header'>
+      <div class='hero-media absolute inset-0'>
+        <Image
+          src={heroVisual}
+          alt='Minimalistic architectural interior'
+          class='h-full w-full object-cover'
+          loading='eager'
+          widths={[720, 1080, 1600, 2200]}
+          sizes='100vw'
+        />
+        <div class='hero-veil absolute inset-0' aria-hidden='true'></div>
       </div>
 
-      {/* Get template removed */}
+      <div class='relative z-10 mx-auto flex min-h-[88vh] w-full max-w-[70rem] flex-col justify-end px-4 pb-14 pt-28 sm:px-7 sm:pb-16 lg:px-10'>
+        <div class='hero-copy max-w-2xl'>
+          <p class='tech-label mb-4 text-white/75'>Personal archive</p>
+          <h1 class='brand-title text-white'>Yokohama Snowly</h1>
+          <p class='mt-5 max-w-xl text-base leading-relaxed text-white/80 sm:text-lg'>
+            CS / Applied Math / Neuroscience — building clear systems with quiet precision.
+          </p>
+          <div class='mt-8 flex flex-wrap items-center gap-3'>
+            <a class='cta-primary' href={withBase('blog')}>Read the blog</a>
+            <a class='cta-ghost' href={withBase('about')}>About me</a>
+          </div>
+          <div class='hero-rule mt-10 h-px w-28 bg-white/50'></div>
+        </div>
+      </div>
     </section>
 
-    <div id='content' class='animate flex flex-col gap-y-10 md:w-4/5 lg:w-5/6'>
-      <Section title='About'>
-        <p class='text-muted-foreground'>Developer / Designer/<s>Pre-Med</s></p>
-        <p class='text-muted-foreground'>
-          你好，我是Yokohama Snowly，在米大修读CS/Applied Math/Neuroscience。<br />
-          在我的闲暇时光，我喜欢玩各类射击游戏，魂类游戏和音乐游戏，不过我最喜欢的还是国际象棋和击剑运动
+    <div id='content' class='animate mx-auto flex w-full flex-col gap-y-14 md:w-4/5 lg:w-5/6'>
+      <Section title='About' index='01'>
+        <p class='text-muted-foreground'>Developer / Designer</p>
+        <p class='text-muted-foreground leading-relaxed'>
+          你好，我是 Yokohama Snowly，在米大修读 CS / Applied Math / Neuroscience。<br />
+          闲暇时喜欢射击、魂类与音游；国际象棋和击剑是更持久的兴趣。
         </p>
-        <Button
-          title='More about me'
-          class='w-fit self-end'
-          href={withBase('about')}
-          variant='ahead'
-        />
+        <a class='link-ahead mt-2 self-end' href={withBase('about')}>More about me</a>
       </Section>
+
       {
         allPostsByDate.length > 0 && (
-          <Section title='Posts'>
-            <ul class='flex flex-col gap-y-1.5 sm:gap-y-2'>
+          <Section title='Posts' index='02'>
+            <ul class='post-list flex flex-col'>
               {allPostsByDate.map((p) => (
-                <li class='flex flex-col gap-x-2 sm:flex-row'>
-                  <PostPreview post={p} />
+                <li>
+                  <a class='post-row group' href={withBase(`blog/${p.id}`)} data-astro-prefetch>
+                    <FormattedDate
+                      class='post-date font-mono text-xs text-muted-foreground'
+                      date={p.data.updatedDate ?? p.data.publishDate}
+                    />
+                    <span class='post-title group-hover:text-primary'>{p.data.title}</span>
+                    <span class='post-arrow text-muted-foreground group-hover:text-primary' aria-hidden='true'>
+                      →
+                    </span>
+                  </a>
                 </li>
               ))}
             </ul>
-            <Button
-              title='More posts'
-              class='w-fit self-end'
-              href={withBase('blog')}
-              variant='ahead'
-            />
+            <a class='link-ahead mt-3 self-end' href={withBase('blog')}>More posts</a>
           </Section>
         )
       }
 
-      {
-        /* <Section title='Experience'>
-      <Card
-        heading='Lorem Ipsum'
-        subheading='Sit amet consectetur'
-        date='Dec 2022 - Nov 2023'
-        imagePath='/src/assets/about-astro.png'
-        altText='Lorem, ipsum dolor sit'
-        imageClass='h-12 w-auto md:-start-16'
-      >
-        <ul class='ms-4 list-disc text-muted-foreground'>
-          <li>
-            Lorem, ipsum dolor sit amet consectetur adipisicing elit. Dolore debitis recusandae, ut
-            molestiae laboriosam pariatur!
-
-            <li>Lorem ipsum dolor sit amet consectetur adipisicing elit. Molestiae, pariatur!</li>
-          </li>
+      <Section title='Education' index='03'>
+        <ul class='flex flex-col divide-y divide-border border-y border-border'>
+          {
+            education.map((item) => (
+              <li class='flex flex-col gap-1 py-4 sm:flex-row sm:items-baseline sm:justify-between sm:gap-6'>
+                <h3 class='text-base font-medium'>{item.heading}</h3>
+                <p class='font-mono text-sm text-muted-foreground'>{item.subheading}</p>
+              </li>
+            ))
+          }
         </ul>
-      </Card>
-      <Card
-        heading='Lorem Ipsum'
-        subheading='Sit amet consectetur'
-        date='Dec 2022 - Nov 2023'
-        imagePath='/src/assets/about-astro.png'
-        altText='Lorem, ipsum dolor sit'
-        imageClass='h-12 w-auto md:-start-16'
-      />
-    </Section> */
-      }
-      <Section title='Education'>
-        <div class='flex flex-col gap-4'>
-            <ProjectCard
-              heading='未来ガジェット研究所'
-              subheading='Brain Computer Interaction for future haven'
-            />
-            <ProjectCard
-              heading='中国人民大学附属中学'
-              subheading='C1'
-            />
+      </Section>
+
+      <Section title='Focus' index='04'>
+        <div class='flex flex-col gap-1 border-y border-border py-4'>
+          <h3 class='text-base font-medium'>South Servery Chess King</h3>
+          <p class='text-sm text-muted-foreground'>
+            在 Wises 和 Hanszen 击败一众高手成为南侧食堂棋王
+          </p>
         </div>
       </Section>
 
-      <Section title='Website List'>
-          <!-- Website List cleared -->
-      </Section>
-
-      <Section title='Certifications'>
-        <Card
-          heading='South Servery Chess King'
-          subheading='在Wises和Hanszen击败一众高手成为南侧食堂棋王'
-        />
-      </Section>
-
-      <Section title='Skills'>
+      <Section title='Skills' index='05'>
         <SkillLayout title='Languages' skills={languages} />
         <SkillLayout title='Frontend' skills={frontend} />
         <SkillLayout title='Backend' skills={backend} />
       </Section>
     </div>
-    <Quote class='mt-12' />
+
+    <div class='mt-16 flex justify-center'>
+      <Quote />
+    </div>
   </main>
 </PageLayout>
+
+<style>
+  .brand-title {
+    font-size: clamp(2.6rem, 8vw, 4.75rem);
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    line-height: 0.95;
+  }
+
+  .hero-veil {
+    background:
+      linear-gradient(180deg, hsl(216 28% 8% / 0.18) 0%, hsl(216 28% 8% / 0.55) 48%, hsl(216 28% 8% / 0.82) 100%),
+      linear-gradient(90deg, hsl(216 28% 8% / 0.35) 0%, transparent 55%);
+  }
+
+  .cta-primary,
+  .cta-ghost,
+  .link-ahead {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.5rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 0.25rem;
+    font-size: 0.92rem;
+    font-weight: 550;
+    letter-spacing: 0.01em;
+    transition:
+      background-color 0.2s ease,
+      color 0.2s ease,
+      border-color 0.2s ease,
+      transform 0.2s ease;
+  }
+
+  .cta-primary {
+    background: hsl(0 0% 100% / 0.95);
+    color: hsl(216 28% 12%);
+  }
+
+  .cta-primary:hover {
+    background: hsl(0 0% 100%);
+    color: hsl(191 72% 28%);
+    transform: translateY(-1px);
+  }
+
+  .cta-ghost {
+    border: 1px solid hsl(0 0% 100% / 0.35);
+    color: hsl(0 0% 100% / 0.92);
+    background: hsl(0 0% 100% / 0.04);
+  }
+
+  .cta-ghost:hover {
+    border-color: hsl(0 0% 100% / 0.7);
+    color: hsl(0 0% 100%);
+    background: hsl(0 0% 100% / 0.1);
+  }
+
+  .link-ahead {
+    width: fit-content;
+    padding-inline: 0;
+    color: hsl(var(--primary));
+  }
+
+  .link-ahead::after {
+    content: ' →';
+    transition: margin-inline-start 0.2s ease;
+  }
+
+  .link-ahead:hover::after {
+    margin-inline-start: 0.2rem;
+  }
+
+  .post-list {
+    border-top: 1px solid hsl(var(--border));
+  }
+
+  .post-row {
+    display: grid;
+    grid-template-columns: 6.5rem 1fr auto;
+    align-items: baseline;
+    gap: 0.85rem;
+    padding-block: 0.9rem;
+    border-bottom: 1px solid hsl(var(--border));
+    color: inherit;
+  }
+
+  .post-title {
+    font-weight: 500;
+    transition: color 0.2s ease;
+  }
+
+  .post-arrow {
+    transition:
+      color 0.2s ease,
+      transform 0.2s ease;
+  }
+
+  .post-row:hover .post-arrow {
+    transform: translateX(0.2rem);
+  }
+
+  @media (max-width: 640px) {
+    .post-row {
+      grid-template-columns: 1fr auto;
+      gap: 0.4rem 0.75rem;
+    }
+
+    .post-date {
+      grid-column: 1 / -1;
+    }
+  }
+</style>

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -12,7 +12,7 @@ export const theme: ThemeUserConfig = {
   /** Will be used in index page & copyright declaration */
   author: 'Yechen(Linus) Liu',
   /** Description metadata for your website. Can be used in page metadata. */
-  description: 'Stay hungry, stay foolish',
+  description: 'Yokohama Snowly — CS / Applied Math / Neuroscience notes and projects.',
   /** The default favicon for your site which should be a path to an image in the `public/` directory. */
   favicon: withStaticBase('favicon/favicon.ico'),
   /** Specify the default language for this site. */
@@ -87,7 +87,7 @@ export const theme: ThemeUserConfig = {
     /** Enable displaying a “Astro & Pure theme powered” link in your site’s footer. */
     credits: true,
     /** Optional details about the social media accounts for this site. */
-    social: { github: 'https://github.com/cworld1/astro-theme-pure' }
+    social: { github: 'https://github.com/user309dec/YokohamaSnowlyBlog' }
   },
 
   content: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refreshes the site into a cool tech-minimal look: teal accents, Satoshi + IBM Plex Mono, subtle grid atmosphere, and a light default theme.
- Rebuilds the homepage around a brand-led full-bleed hero, cleaner section rhythm, and list-style posts/education/skills instead of dense cards.
- Tightens header/footer chrome (lighter sticky bar, mono labels) while keeping the existing Astro Pure structure and routes.

## Test plan
- [x] `bun check`
- [x] `bun run build`
- [x] Preview `/YokohamaSnowlyBlog` on desktop and mobile (hero contrast verified)
- [ ] Toggle light/dark theme and verify contrast remains readable

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2458e98-a4f4-470b-af91-df0940e7b251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2458e98-a4f4-470b-af91-df0940e7b251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

