### PR TITLE
Set up Cursor Cloud dev environment (Bun + Astro)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@
 
 This is a static blog built with Astro + `astro-pure`, managed with the **Bun** package manager (`bun.lock`). Standard scripts live in `package.json` (`dev`, `check`, `build`, `lint`, `format`).
 
-- Bun is preinstalled in the cloud environment and on `PATH`; the update script runs `bun install`. Use Bun (not npm/pnpm) so the lockfile stays consistent.
+- Bun is the required package manager, but it is **not guaranteed to be preinstalled** on the PATH. The update script installs Bun (to `~/.bun`) if `bun` is missing, then runs `bun install`; `~/.bun/bin` is added to `PATH` via `~/.bashrc`. If `bun` is not found in an interactive shell, run `export PATH="$HOME/.bun/bin:$PATH"`. Use Bun (not npm/pnpm) so the lockfile stays consistent.
 - Run the dev server with `bun dev` (Astro dev server on port `4321`).
-- **The site uses a base path.** The dev server serves everything under `http://localhost:4321/YokohamaSnowlyBlog` — the bare root `http://localhost:4321/` returns 404. Always include the `/YokohamaSnowlyBlog` prefix when loading pages or writing links (see `src/config/site.ts` / `withStaticBase(...)` helpers).
+- **The site uses a base path AND `trailingSlash: 'never'`** (see `astro.config.ts`). The dev server serves everything under `http://localhost:4321/YokohamaSnowlyBlog` with **no trailing slash** — both the bare root `http://localhost:4321/` and the trailing-slash form `http://localhost:4321/YokohamaSnowlyBlog/` return 404. Always include the `/YokohamaSnowlyBlog` prefix and omit trailing slashes when loading pages or writing links (see `src/config/site.ts`).
 - `bun check` (astro check) and `bun build` both pass cleanly. `bun build` also runs `astro-pure check` and Pagefind indexing.
 - `bun lint` currently reports pre-existing errors in `src/` (unused vars, `no-explicit-any`, etc.); these are existing repo issues, not an environment problem.
 - Content lives in `src/content/{blog,thoughts,docs}` and follows the schema in `src/content.config.ts`. The dev server hot-reloads content edits.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this Astro + `astro-pure` blog (managed with Bun).

Environment configuration:
- Update script installs Bun (`~/.bun`) if missing, then runs `bun install`.
- Corrected `AGENTS.md` `## Cursor Cloud specific instructions`: Bun is **not** guaranteed preinstalled (it was absent on PATH), and the dev server uses `trailingSlash: 'never'` so pages are served under `http://localhost:4321/YokohamaSnowlyBlog` with **no** trailing slash (bare root and trailing-slash forms return 404).

## Verification

| Step | Command | Result |
| --- | --- | --- |
| Install | `bun install` | 739 packages installed |
| Typecheck | `bun check` | 0 errors / 0 warnings |
| Build | `bun run build` | 35 pages built + Pagefind index |
| Dev server | `bun dev` | serving on `:4321/YokohamaSnowlyBlog` (HTTP 200) |

Hello-world task: added a temporary Thoughts post, confirmed it hot-reloaded and rendered on `/thoughts` (with tags), then removed it. Only the `AGENTS.md` doc fix is committed.

[astro_blog_dev_hello_world.mp4](https://cursor.com/agents/bc-04478b6f-63b8-4188-9bb1-0150497e7b11/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_blog_dev_hello_world.mp4)
[Hello world thought rendered on Thoughts page](https://cursor.com/agents/bc-04478b6f-63b8-4188-9bb1-0150497e7b11/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fthoughts_hello_world.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04478b6f-63b8-4188-9bb1-0150497e7b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04478b6f-63b8-4188-9bb1-0150497e7b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

