### PR TITLE
Add audio-reactive fluid aurora hero and generative ambient player

### DIFF
--- a/src/components/custom/AmbientPlayer.astro
+++ b/src/components/custom/AmbientPlayer.astro
@@ -1,0 +1,310 @@
+---
+// Floating ambient-music toggle. Music is synthesized live with the Web Audio
+// API (no audio files): a slowly drifting chord pad, pentatonic plucks through
+// a feedback delay, a sine sub drone and generated-impulse reverb.
+// Publishes live frequency levels to window.__AMBIENT__ for the hero visuals.
+---
+
+<button
+  id='ambient-toggle'
+  class='ambient-toggle'
+  type='button'
+  aria-pressed='false'
+  title='Ambient sound'
+>
+  <span class='eq' aria-hidden='true'>
+    <span></span><span></span><span></span><span></span><span></span>
+  </span>
+  <span class='ambient-label'>AMBIENT</span>
+</button>
+
+<style>
+  .ambient-toggle {
+    position: fixed;
+    right: 1.25rem;
+    bottom: 1.25rem;
+    z-index: 40;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.5rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--card) / 0.72);
+    color: hsl(var(--muted-foreground));
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    cursor: pointer;
+    transition:
+      color 0.25s ease,
+      border-color 0.25s ease,
+      box-shadow 0.25s ease;
+  }
+
+  .ambient-toggle:hover {
+    color: hsl(var(--primary));
+    border-color: hsl(var(--primary) / 0.5);
+  }
+
+  .ambient-toggle[aria-pressed='true'] {
+    color: hsl(var(--primary));
+    border-color: hsl(var(--primary) / 0.55);
+    box-shadow: 0 0 calc(6px + var(--amp, 0) * 22px) hsl(var(--surface-glow) / 0.45);
+  }
+
+  .eq {
+    display: inline-flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 14px;
+  }
+
+  .eq span {
+    width: 2.5px;
+    height: 3px;
+    border-radius: 1px;
+    background: currentColor;
+    transition: height 0.09s linear;
+  }
+
+  @media (max-width: 640px) {
+    .ambient-label {
+      display: none;
+    }
+    .ambient-toggle {
+      padding: 0.55rem 0.7rem;
+    }
+  }
+</style>
+
+<script>
+  const btn = document.getElementById('ambient-toggle') as HTMLButtonElement | null
+  const bars = btn ? Array.from(btn.querySelectorAll('.eq span')) : []
+  const levels = { bass: 0, mid: 0, high: 0, level: 0, playing: false }
+  ;(window as any).__AMBIENT__ = levels
+
+  // A-minor pentatonic space; chords stay diatonic so drifting always resolves
+  const CHORDS = [
+    [45, 52, 60, 64], // Am
+    [41, 48, 57, 60], // F
+    [48, 55, 62, 64], // C add9
+    [43, 50, 59, 62] // G
+  ]
+  const SCALE = [57, 60, 62, 64, 67, 69, 72, 74, 76, 79, 81]
+  const mtof = (m: number) => 440 * Math.pow(2, (m - 69) / 12)
+
+  let ctx: AudioContext | null = null
+  let analyser: AnalyserNode | null = null
+  let master: GainNode | null = null
+  let padOscs: OscillatorNode[] = []
+  let bassOsc: OscillatorNode | null = null
+  let reverbIn: GainNode | null = null
+  let delayIn: DelayNode | null = null
+  let pluckTimer = 0
+  let chordTimer = 0
+  let raf = 0
+  let chordIdx = 0
+
+  function makeImpulse(ac: AudioContext, seconds: number) {
+    const rate = ac.sampleRate
+    const len = Math.floor(rate * seconds)
+    const buf = ac.createBuffer(2, len, rate)
+    for (let ch = 0; ch < 2; ch++) {
+      const data = buf.getChannelData(ch)
+      for (let i = 0; i < len; i++) {
+        data[i] = (Math.random() * 2 - 1) * Math.pow(1 - i / len, 2.6)
+      }
+    }
+    return buf
+  }
+
+  function buildEngine() {
+    const AC = window.AudioContext || (window as any).webkitAudioContext
+    const ac: AudioContext = new AC()
+    ctx = ac
+
+    master = ac.createGain()
+    master.gain.value = 0
+    const comp = ac.createDynamicsCompressor()
+    comp.threshold.value = -22
+    comp.ratio.value = 6
+    analyser = ac.createAnalyser()
+    analyser.fftSize = 256
+    analyser.smoothingTimeConstant = 0.82
+    master.connect(comp).connect(analyser).connect(ac.destination)
+
+    // Reverb bus
+    const verb = ac.createConvolver()
+    verb.buffer = makeImpulse(ac, 3.2)
+    const verbGain = ac.createGain()
+    verbGain.gain.value = 0.5
+    reverbIn = ac.createGain()
+    reverbIn.connect(verb).connect(verbGain).connect(master)
+
+    // Feedback delay bus (plucks) feeding the reverb too
+    delayIn = ac.createDelay(1.0)
+    delayIn.delayTime.value = 0.42
+    const fb = ac.createGain()
+    fb.gain.value = 0.34
+    const delayOut = ac.createGain()
+    delayOut.gain.value = 0.5
+    delayIn.connect(fb).connect(delayIn)
+    delayIn.connect(delayOut)
+    delayOut.connect(master)
+    delayOut.connect(reverbIn)
+
+    // Chord pad: four detuned saws through a slowly breathing lowpass
+    const padFilter = ac.createBiquadFilter()
+    padFilter.type = 'lowpass'
+    padFilter.frequency.value = 520
+    padFilter.Q.value = 0.8
+    const padGain = ac.createGain()
+    padGain.gain.value = 0.05
+    padFilter.connect(padGain)
+    padGain.connect(master)
+    padGain.connect(reverbIn)
+
+    const lfo = ac.createOscillator()
+    lfo.frequency.value = 0.05
+    const lfoAmt = ac.createGain()
+    lfoAmt.gain.value = 220
+    lfo.connect(lfoAmt).connect(padFilter.frequency)
+    lfo.start()
+
+    padOscs = CHORDS[0].map((m, i) => {
+      const osc = ac.createOscillator()
+      osc.type = 'sawtooth'
+      osc.frequency.value = mtof(m)
+      osc.detune.value = i % 2 === 0 ? 4 : -4
+      osc.connect(padFilter)
+      osc.start()
+      return osc
+    })
+
+    // Sub drone follows the chord root, one octave down
+    bassOsc = ac.createOscillator()
+    bassOsc.type = 'sine'
+    bassOsc.frequency.value = mtof(CHORDS[0][0] - 12)
+    const bassGain = ac.createGain()
+    bassGain.gain.value = 0.11
+    bassOsc.connect(bassGain).connect(master)
+    bassOsc.start()
+
+    const glideChord = () => {
+      chordIdx = (chordIdx + 1) % CHORDS.length
+      const chord = CHORDS[chordIdx]
+      const t = ac.currentTime
+      padOscs.forEach((osc, i) => {
+        osc.frequency.setTargetAtTime(mtof(chord[i]), t, 2.5)
+      })
+      bassOsc?.frequency.setTargetAtTime(mtof(chord[0] - 12), t, 2.5)
+      chordTimer = window.setTimeout(glideChord, 11000 + Math.random() * 5000)
+    }
+    chordTimer = window.setTimeout(glideChord, 12000)
+
+    const pluck = () => {
+      const midi = SCALE[Math.floor(Math.random() * SCALE.length)]
+      const t = ac.currentTime
+      const osc = ac.createOscillator()
+      osc.type = 'triangle'
+      osc.frequency.value = mtof(midi)
+      const env = ac.createGain()
+      env.gain.setValueAtTime(0, t)
+      env.gain.linearRampToValueAtTime(0.08 + Math.random() * 0.05, t + 0.012)
+      const decay = 1.1 + Math.random() * 1.4
+      env.gain.exponentialRampToValueAtTime(0.0001, t + decay)
+      osc.connect(env)
+      env.connect(delayIn!)
+      env.connect(reverbIn!)
+      osc.start(t)
+      osc.stop(t + decay + 0.1)
+      pluckTimer = window.setTimeout(pluck, 350 + Math.random() * 900)
+    }
+    pluckTimer = window.setTimeout(pluck, 600)
+  }
+
+  const freq = new Uint8Array(128)
+  function meterLoop() {
+    if (!levels.playing || !analyser) return
+    analyser.getByteFrequencyData(freq)
+    const avg = (a: number, b: number) => {
+      let s = 0
+      for (let i = a; i < b; i++) s += freq[i]
+      return s / (b - a) / 255
+    }
+    // fftSize 256 @ 44.1kHz -> ~172Hz per bin; this soft ambient palette
+    // carries most energy below ~3kHz, so bands sit low with makeup gain.
+    levels.bass = Math.min(1, avg(1, 5) * 1.15)
+    levels.mid = Math.min(1, avg(5, 17) * 1.7)
+    levels.high = Math.min(1, avg(17, 64) * 2.6)
+    levels.level = (levels.bass + levels.mid + levels.high) / 3
+
+    bars.forEach((bar, i) => {
+      const v = [levels.bass, levels.mid, levels.level, levels.mid, levels.high][i] ?? 0
+      ;(bar as HTMLElement).style.height = `${3 + v * 12}px`
+    })
+    btn?.style.setProperty('--amp', levels.level.toFixed(3))
+    raf = requestAnimationFrame(meterLoop)
+  }
+
+  function resetMeter() {
+    cancelAnimationFrame(raf)
+    levels.bass = levels.mid = levels.high = levels.level = 0
+    bars.forEach((bar) => ((bar as HTMLElement).style.height = '3px'))
+    btn?.style.setProperty('--amp', '0')
+  }
+
+  async function startAudio() {
+    if (!ctx) buildEngine()
+    await ctx!.resume()
+    const t = ctx!.currentTime
+    master!.gain.cancelScheduledValues(t)
+    master!.gain.setTargetAtTime(0.9, t, 0.8)
+    levels.playing = true
+    btn?.setAttribute('aria-pressed', 'true')
+    localStorage.setItem('ambient-audio', 'on')
+    raf = requestAnimationFrame(meterLoop)
+  }
+
+  async function stopAudio() {
+    levels.playing = false
+    btn?.setAttribute('aria-pressed', 'false')
+    localStorage.setItem('ambient-audio', 'off')
+    if (ctx && master) {
+      const t = ctx.currentTime
+      master.gain.cancelScheduledValues(t)
+      master.gain.setTargetAtTime(0, t, 0.25)
+      await new Promise((r) => setTimeout(r, 700))
+      if (!levels.playing) await ctx.suspend()
+    }
+    resetMeter()
+  }
+
+  btn?.addEventListener('click', () => {
+    if (levels.playing) void stopAudio()
+    else void startAudio()
+  })
+
+  // If the visitor had ambient on, resume on their first interaction
+  // (browsers block audio before a user gesture).
+  if (localStorage.getItem('ambient-audio') === 'on') {
+    const resume = (e: Event) => {
+      // Let the toggle's own click handler win, otherwise this fires first
+      // and the click immediately toggles the audio back off.
+      if (btn && e.target instanceof Node && btn.contains(e.target)) return
+      window.removeEventListener('pointerdown', resume)
+      window.removeEventListener('keydown', resume)
+      if (!levels.playing) void startAudio()
+    }
+    window.addEventListener('pointerdown', resume)
+    window.addEventListener('keydown', resume)
+  }
+
+  window.addEventListener('beforeunload', () => {
+    window.clearTimeout(pluckTimer)
+    window.clearTimeout(chordTimer)
+  })
+</script>

--- a/src/components/custom/HeroFluid.astro
+++ b/src/components/custom/HeroFluid.astro
@@ -1,0 +1,233 @@
+---
+// Audio-reactive fluid aurora rendered with WebGL, blended over the hero image.
+// Reads live frequency levels from window.__AMBIENT__ (set by AmbientPlayer).
+---
+
+<canvas id='hero-fluid' class='hero-fluid' aria-hidden='true'></canvas>
+
+<style>
+  .hero-fluid {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    mix-blend-mode: screen;
+    opacity: 0;
+    transition: opacity 1.6s ease;
+  }
+
+  .hero-fluid.is-live {
+    opacity: 0.9;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hero-fluid {
+      display: none;
+    }
+  }
+</style>
+
+<script>
+  const canvas = document.getElementById('hero-fluid') as HTMLCanvasElement | null
+  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  if (canvas && !reduced) {
+    const gl = canvas.getContext('webgl', {
+      alpha: false,
+      antialias: false,
+      powerPreference: 'low-power'
+    })
+    if (!gl) {
+      canvas.remove()
+    } else {
+      const VERT = `
+        attribute vec2 aPos;
+        void main() { gl_Position = vec4(aPos, 0.0, 1.0); }
+      `
+      const FRAG = `
+        precision highp float;
+        uniform vec2 uRes;
+        uniform float uTime;
+        uniform vec2 uMouse;
+        uniform float uBass;
+        uniform float uMid;
+        uniform float uHigh;
+        uniform float uLevel;
+
+        float hash(vec2 p) {
+          return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+        }
+        float noise(vec2 p) {
+          vec2 i = floor(p);
+          vec2 f = fract(p);
+          vec2 u = f * f * (3.0 - 2.0 * f);
+          return mix(
+            mix(hash(i), hash(i + vec2(1.0, 0.0)), u.x),
+            mix(hash(i + vec2(0.0, 1.0)), hash(i + vec2(1.0, 1.0)), u.x),
+            u.y
+          );
+        }
+        float fbm(vec2 p) {
+          float v = 0.0;
+          float a = 0.5;
+          for (int i = 0; i < 5; i++) {
+            v += a * noise(p);
+            p = p * 2.03 + vec2(1.7, 9.2);
+            a *= 0.5;
+          }
+          return v;
+        }
+
+        void main() {
+          vec2 p = (gl_FragCoord.xy - 0.5 * uRes) / uRes.y;
+          float t = uTime * 0.07;
+
+          // Domain-warped flow field: two layers of fbm feeding each other
+          vec2 m = (uMouse - 0.5) * 0.5;
+          vec2 q = vec2(
+            fbm(p * 1.6 + t + m),
+            fbm(p * 1.6 - t * 1.25)
+          );
+          vec2 r = vec2(
+            fbm(p * 2.2 + q * 1.8 + vec2(1.7, 9.2) + t * 0.7),
+            fbm(p * 2.2 + q * 1.8 + vec2(8.3, 2.8) - t * 0.5)
+          );
+          float f = fbm(p * 2.4 + r * (2.1 + uBass * 1.6));
+
+          // Aurora ribbons in the site's teal/cyan family with a violet edge
+          float rib = smoothstep(0.26, 0.78, f);
+          vec3 deepTeal = vec3(0.04, 0.30, 0.40);
+          vec3 cyan = vec3(0.16, 0.72, 0.84);
+          vec3 violet = vec3(0.42, 0.38, 0.82);
+          vec3 col = mix(deepTeal, cyan, rib);
+          col = mix(col, violet, smoothstep(0.55, 0.95, q.y) * 0.45);
+          col *= rib * (0.85 + uLevel * 1.1 + uMid * 0.4);
+          col += cyan * pow(rib, 3.0) * (0.3 + uBass * 0.5);
+
+          // Volumetric light rays sweeping from the upper left
+          vec2 src = vec2(-0.62, 0.55);
+          vec2 d = p - src;
+          float ang = atan(d.y, d.x);
+          float rays = pow(abs(sin(ang * 9.0 + t * 3.0 + fbm(vec2(ang * 3.0, t)) * 2.0)), 6.0);
+          rays *= exp(-length(d) * 1.15) * (0.3 + uHigh * 1.3);
+          col += vec3(0.5, 0.85, 0.95) * rays;
+
+          // Sparse sparkles that only appear with treble energy
+          float sp = step(0.9975 - uHigh * 0.003, hash(floor(p * 90.0) + floor(uTime * 8.0)));
+          col += sp * vec3(0.7, 0.95, 1.0) * uHigh * 0.8;
+
+          // Fade toward the bottom so hero text stays readable
+          col *= smoothstep(-0.68, 0.28, p.y + 0.3);
+
+          gl_FragColor = vec4(col, 1.0);
+        }
+      `
+
+      const compile = (type: number, src: string) => {
+        const s = gl.createShader(type)!
+        gl.shaderSource(s, src)
+        gl.compileShader(s)
+        return s
+      }
+      const prog = gl.createProgram()!
+      gl.attachShader(prog, compile(gl.VERTEX_SHADER, VERT))
+      gl.attachShader(prog, compile(gl.FRAGMENT_SHADER, FRAG))
+      gl.linkProgram(prog)
+
+      if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+        canvas.remove()
+      } else {
+        gl.useProgram(prog)
+        const buf = gl.createBuffer()
+        gl.bindBuffer(gl.ARRAY_BUFFER, buf)
+        gl.bufferData(
+          gl.ARRAY_BUFFER,
+          new Float32Array([-1, -1, 3, -1, -1, 3]),
+          gl.STATIC_DRAW
+        )
+        const loc = gl.getAttribLocation(prog, 'aPos')
+        gl.enableVertexAttribArray(loc)
+        gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0)
+
+        const uRes = gl.getUniformLocation(prog, 'uRes')
+        const uTime = gl.getUniformLocation(prog, 'uTime')
+        const uMouse = gl.getUniformLocation(prog, 'uMouse')
+        const uBass = gl.getUniformLocation(prog, 'uBass')
+        const uMid = gl.getUniformLocation(prog, 'uMid')
+        const uHigh = gl.getUniformLocation(prog, 'uHigh')
+        const uLevel = gl.getUniformLocation(prog, 'uLevel')
+
+        const resize = () => {
+          const dpr = Math.min(window.devicePixelRatio || 1, 1.5)
+          const w = Math.round(canvas.clientWidth * dpr)
+          const h = Math.round(canvas.clientHeight * dpr)
+          if (canvas.width !== w || canvas.height !== h) {
+            canvas.width = w
+            canvas.height = h
+            gl.viewport(0, 0, w, h)
+          }
+        }
+        resize()
+        window.addEventListener('resize', resize)
+
+        // Mouse drifts the flow field; lerped for a fluid feel
+        const mouse = { x: 0.5, y: 0.5, tx: 0.5, ty: 0.5 }
+        const hero = canvas.closest('section') ?? document.body
+        hero.addEventListener('pointermove', (e) => {
+          const rect = canvas.getBoundingClientRect()
+          mouse.tx = (e.clientX - rect.left) / rect.width
+          mouse.ty = 1 - (e.clientY - rect.top) / rect.height
+        })
+
+        // Audio levels shared by AmbientPlayer; eased here for smooth visuals
+        const smooth = { bass: 0, mid: 0, high: 0, level: 0 }
+        let visible = true
+        let running = false
+        let raf = 0
+        const start = performance.now()
+
+        const frame = () => {
+          if (!visible || document.hidden) {
+            running = false
+            return
+          }
+          const amb = (window as any).__AMBIENT__ ?? { bass: 0, mid: 0, high: 0, level: 0 }
+          const k = 0.06
+          smooth.bass += (amb.bass - smooth.bass) * k
+          smooth.mid += (amb.mid - smooth.mid) * k
+          smooth.high += (amb.high - smooth.high) * k
+          smooth.level += (amb.level - smooth.level) * k
+          mouse.x += (mouse.tx - mouse.x) * 0.04
+          mouse.y += (mouse.ty - mouse.y) * 0.04
+
+          gl.uniform2f(uRes, canvas.width, canvas.height)
+          gl.uniform1f(uTime, (performance.now() - start) / 1000)
+          gl.uniform2f(uMouse, mouse.x, mouse.y)
+          gl.uniform1f(uBass, smooth.bass)
+          gl.uniform1f(uMid, smooth.mid)
+          gl.uniform1f(uHigh, smooth.high)
+          gl.uniform1f(uLevel, smooth.level)
+          gl.drawArrays(gl.TRIANGLES, 0, 3)
+          raf = requestAnimationFrame(frame)
+        }
+        const ensureRunning = () => {
+          if (!running && visible && !document.hidden) {
+            running = true
+            raf = requestAnimationFrame(frame)
+          }
+        }
+
+        new IntersectionObserver((entries) => {
+          visible = entries[0]?.isIntersecting ?? true
+          if (visible) ensureRunning()
+          else cancelAnimationFrame(raf)
+        }).observe(canvas)
+
+        document.addEventListener('visibilitychange', ensureRunning)
+
+        canvas.classList.add('is-live')
+        ensureRunning()
+      }
+    }
+  }
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,6 +3,7 @@ import { ThemeProvider } from 'astro-pure/components/basic'
 import type { SiteMeta } from 'astro-pure/types'
 import BaseHead from '@/components/BaseHead.astro'
 import config from '@/site-config'
+import AmbientPlayer from '@/components/custom/AmbientPlayer.astro'
 import Footer from '@/components/custom/Footer.astro'
 import Header from '@/components/custom/Header.astro'
 
@@ -58,6 +59,7 @@ const {
       </div>
       <Footer />
     </div>
+    <AmbientPlayer />
 
     {/* Set highlight color */}
     <style define:vars={{ highlightColor }}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import Quote from '@/components/home/Quote.astro'
 import { getBlogCollection, sortMDByDate } from 'astro-pure/server'
 import { FormattedDate } from 'astro-pure/user'
 import heroVisual from '@/assets/projects/angelica-teran-Bk9hpaXHK4o-unsplash.jpg'
+import HeroFluid from '@/components/custom/HeroFluid.astro'
 import PageLayout from '@/layouts/BaseLayout.astro'
 import Section from '@/components/home/Section.astro'
 import SkillLayout from '@/components/home/SkillLayout.astro'
@@ -44,6 +45,7 @@ const education = [
           sizes='100vw'
         />
         <div class='hero-veil absolute inset-0' aria-hidden='true'></div>
+        <HeroFluid />
       </div>
 
       <div class='relative z-10 mx-auto flex min-h-[88vh] w-full max-w-[70rem] flex-col justify-end px-4 pb-14 pt-28 sm:px-7 sm:pb-16 lg:px-10'>


### PR DESCRIPTION
- HeroFluid: WebGL domain-warped fbm aurora with volumetric rays, screen-blended over the hero photo; mouse-driven flow, pauses offscreen/hidden, respects prefers-reduced-motion
- AmbientPlayer: Web Audio generative ambient (pentatonic plucks, gliding chord pad, sub drone, generated-IR reverb) with a floating toggle whose EQ bars follow the live spectrum
- Bass/mid/treble levels drive the shader for audio-reactive visuals